### PR TITLE
PreinstalledCompetitionPackages.md: adding ros-kinetic-multimaster-fkie

### DIFF
--- a/PreinstalledCompetitionPackages.md
+++ b/PreinstalledCompetitionPackages.md
@@ -19,4 +19,4 @@ ros-kinetic-grid-map
 ros-kinetic-rosserial-python 
 ros-kinetic-rosserial-arduino
 ros-kinetic-usb-cam
-
+ros-kinetic-multimaster-fkie


### PR DESCRIPTION
Cabrillo is using multimaster so we will need ros-kinetic-multimaster-fkie